### PR TITLE
Fixed capitalization of figures directory for Linux users.

### DIFF
--- a/jdf-starter.tex
+++ b/jdf-starter.tex
@@ -59,7 +59,7 @@ If your figure includes a white background (e.g. an interface design or graph), 
 
 \begin{figure}[h]
 	\centering
-	\includegraphics[height=6cm]{figures/flowchart.png}
+	\includegraphics[height=6cm]{Figures/flowchart.png}
 	\caption{Make sure your flowcharts are more useful than this one. Source: \href{https://xkcd.com/1195/}{XKCD}.}
 	\label{fig:flowchart}
 \end{figure}


### PR DESCRIPTION
The starter file will not build on Ubuntu, because the figures directory is not capitalized when referenced in the file, but is capitalized in the directory structure. So, this update capitalizes that directory name in the .tex file.