### PR TITLE
added CSLReferences

### DIFF
--- a/jdf-template.pandoc
+++ b/jdf-template.pandoc
@@ -2,6 +2,10 @@
 
 \usepackage{longtable}
 
+\newenvironment{CSLReferences}%
+  {}%
+  {\par}
+
 $if(highlighting-macros)$
 $highlighting-macros$
 $endif$


### PR DESCRIPTION
This is meant to address https://github.com/iamjakewarner/jdf/issues/22 . Following a suggestion made on StackOverflow (https://stackoverflow.com/questions/59193797/pandocs-environment-cslreferences-undefined-when-knitting-rmarkdown-to-pdf-in-r), I added a CSLReferences environment to the jdf-template pandoc. Now the pandoc compile works without producing any errors. 

