### PR TITLE
change reference sorting to nyt (name, year, time)

### DIFF
--- a/jdf.cls
+++ b/jdf.cls
@@ -275,7 +275,7 @@
 \RequirePackage[
 	bibstyle=authoryear,
 	dashed=false,
-	sorting=ynt,
+	sorting=nyt,
 	natbib=true,
 	maxbibnames=99
 ]{biblatex}


### PR DESCRIPTION
Addressing Issue #25 
Changed sorting order from year, name, time to name, year, time to align with text specifications.