### PR TITLE
fix: References authoryear format

### DIFF
--- a/jdf.cls
+++ b/jdf.cls
@@ -273,7 +273,7 @@
 %%
 % References
 \RequirePackage[
-	bibstyle=authoryear,
+	style=authoryear,
 	dashed=false,
 	sorting=ynt,
 	natbib=true,


### PR DESCRIPTION
Authoryear format when I used this repo was displaying as numbers. This fix is to display in author year format